### PR TITLE
add MultyArrayStamped msgs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,12 @@ project(ros_np_multiarray)
 ## Find catkin macros and libraries
 ## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)
 ## is used, also find other catkin packages
-find_package(catkin REQUIRED)
+find_package(catkin REQUIRED COMPONENTS
+	roscpp
+	rospy
+	std_msgs
+	message_generation
+)
 
 ## System dependencies are found with CMake's conventions
 # find_package(Boost REQUIRED COMPONENTS system)
@@ -43,11 +48,19 @@ catkin_python_setup()
 ##   * add every package in MSG_DEP_SET to generate_messages(DEPENDENCIES ...)
 
 ## Generate messages in the 'msg' folder
-# add_message_files(
-#   FILES
-#   Message1.msg
-#   Message2.msg
-# )
+add_message_files(
+	FILES
+	Float32MultiArrayStamped.msg
+	Float64MultiArrayStamped.msg
+	Int8MultiArrayStamped.msg
+	Int16MultiArrayStamped.msg
+	Int32MultiArrayStamped.msg
+	Int64MultiArrayStamped.msg
+	UInt8MultiArrayStamped.msg
+	UInt16MultiArrayStamped.msg
+	UInt32MultiArrayStamped.msg
+	UInt64MultiArrayStamped.msg
+)
 
 ## Generate services in the 'srv' folder
 # add_service_files(
@@ -64,10 +77,10 @@ catkin_python_setup()
 # )
 
 ## Generate added messages and services with any dependencies listed here
-# generate_messages(
-#   DEPENDENCIES
-#   std_msgs  # Or other packages containing msgs
-# )
+generate_messages(
+	DEPENDENCIES
+	std_msgs  # Or other packages containing msgs
+)
 
 ################################################
 ## Declare ROS dynamic reconfigure parameters ##
@@ -101,7 +114,7 @@ catkin_python_setup()
 catkin_package(
 #  INCLUDE_DIRS include
 #  LIBRARIES ros_np_multiarray
-#  CATKIN_DEPENDS other_catkin_pkg
+	CATKIN_DEPENDS message_runtime
 #  DEPENDS system_lib
 )
 

--- a/msg/Float32MultiArrayStamped.msg
+++ b/msg/Float32MultiArrayStamped.msg
@@ -1,0 +1,2 @@
+std_msgs/Header header
+std_msgs/Float32MultiArray multi_array

--- a/msg/Float64MultiArrayStamped.msg
+++ b/msg/Float64MultiArrayStamped.msg
@@ -1,0 +1,2 @@
+std_msgs/Header header
+std_msgs/Float64MultiArray multi_array

--- a/msg/Int16MultiArrayStamped.msg
+++ b/msg/Int16MultiArrayStamped.msg
@@ -1,0 +1,2 @@
+std_msgs/Header header
+std_msgs/Int16MultiArray multi_array

--- a/msg/Int32MultiArrayStamped.msg
+++ b/msg/Int32MultiArrayStamped.msg
@@ -1,0 +1,2 @@
+std_msgs/Header header
+std_msgs/Int32MultiArray multi_array

--- a/msg/Int64MultiArrayStamped.msg
+++ b/msg/Int64MultiArrayStamped.msg
@@ -1,0 +1,2 @@
+std_msgs/Header header
+std_msgs/Int64MultiArray multi_array

--- a/msg/Int8MultiArrayStamped.msg
+++ b/msg/Int8MultiArrayStamped.msg
@@ -1,0 +1,2 @@
+std_msgs/Header header
+std_msgs/Int8MultiArray multi_array

--- a/msg/UInt16MultiArrayStamped.msg
+++ b/msg/UInt16MultiArrayStamped.msg
@@ -1,0 +1,2 @@
+std_msgs/Header header
+std_msgs/UInt16MultiArray multi_array

--- a/msg/UInt32MultiArrayStamped.msg
+++ b/msg/UInt32MultiArrayStamped.msg
@@ -1,0 +1,2 @@
+std_msgs/Header header
+std_msgs/UInt32MultiArray multi_array

--- a/msg/UInt64MultiArrayStamped.msg
+++ b/msg/UInt64MultiArrayStamped.msg
@@ -1,0 +1,2 @@
+std_msgs/Header header
+std_msgs/UInt64MultiArray multi_array

--- a/msg/UInt8MultiArrayStamped.msg
+++ b/msg/UInt8MultiArrayStamped.msg
@@ -1,0 +1,2 @@
+std_msgs/Header header
+std_msgs/UInt8MultiArray multi_array

--- a/package.xml
+++ b/package.xml
@@ -37,13 +37,13 @@
   <!--   <build_depend>roscpp</build_depend> -->
   <!--   <exec_depend>roscpp</exec_depend> -->
   <!-- Use build_depend for packages you need at compile time: -->
-  <!--   <build_depend>message_generation</build_depend> -->
+  <build_depend>message_generation</build_depend>
   <!-- Use build_export_depend for packages you need in order to build against this package: -->
   <!--   <build_export_depend>message_generation</build_export_depend> -->
   <!-- Use buildtool_depend for build tool packages: -->
   <!--   <buildtool_depend>catkin</buildtool_depend> -->
   <!-- Use exec_depend for packages you need at runtime: -->
-  <!--   <exec_depend>message_runtime</exec_depend> -->
+  <exec_depend>message_runtime</exec_depend>
   <!-- Use test_depend for packages you need only for testing: -->
   <!--   <test_depend>gtest</test_depend> -->
   <!-- Use doc_depend for packages you need only for building documentation: -->

--- a/src/ros_np_multiarray/ros_np_multiarray.py
+++ b/src/ros_np_multiarray/ros_np_multiarray.py
@@ -15,7 +15,7 @@ def _numpy_to_multiarray(multiarray_type, np_array):
     return multiarray
 
 def _multiarray_to_numpy(pytype, dtype, multiarray):
-    dims = map(lambda x: x.size, multiarray.layout.dim)
+    dims = tuple(map(lambda x: x.size, multiarray.layout.dim))
     return np.array(multiarray.data, dtype=pytype).reshape(dims).astype(dtype)
 
 


### PR DESCRIPTION
The conversion is now compatible with Python3 (by explicitly converting the output of `map` to a tuple.
ROS messages defining multy-arrays with timestamps.