### PR TITLE
Example Python3 compatibility + requirements.txt

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Convert between numpy ndarray and ros multiarray message.
 This is a simple example.
 
 ```py
-import ros_np_multiarray as rnm
+from ros_np_multiarray import ros_np_multiarray as rnm
 import numpy as np
 
 print(rnm.to_multiarray_f32(np.array([[[1.0, 2.0], [3.0, 4.0]]], dtype=np.float32)))

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+catkin_pkg==0.4.24
+numpy==1.19.5


### PR DESCRIPTION
The import statement of the example in the README is now Python3 compatible.
A requirements.txt file generated with pipreqs have been added.